### PR TITLE
Apply African Puzzle brand styling to admin panel

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,5 @@
+logo_url: https://africanpuzzle.com/images/logo-bright.svg
+
 backend:
   name: github
   repo: african-puzzle/website-frontend

--- a/index.html
+++ b/index.html
@@ -4,7 +4,34 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Content Manager — African Puzzle</title>
-  <link rel="icon" type="image/svg+xml" href="https://africanpuzzle.com/favicon.svg" />
+  <link rel="icon" type="image/png" sizes="32x32" href="https://africanpuzzle.com/favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="https://africanpuzzle.com/favicon-16.png" />
+  <link rel="apple-touch-icon" href="https://africanpuzzle.com/apple-touch-icon.png" />
+
+  <!-- Brand fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&family=Montserrat:wght@400;500;600&display=swap"
+    rel="stylesheet"
+  />
+
+  <style>
+    /* African Puzzle brand theming for Sveltia CMS */
+    :root {
+      --sui-primary-accent-color-light: #f3e8ff;
+      --sui-primary-accent-color: #8C30F5;
+      --sui-primary-accent-color-dark: #6b21a8;
+      --sui-primary-accent-color-inverted: #ffffff;
+      --sui-primary-font-family: 'Montserrat', system-ui, sans-serif;
+      --sui-primary-heading-font-family: 'Nunito', system-ui, sans-serif;
+    }
+
+    /* Style the login/auth screen */
+    [class*="login"], [class*="auth"] {
+      font-family: 'Montserrat', system-ui, sans-serif;
+    }
+  </style>
 </head>
 <body>
   <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js" type="module"></script>


### PR DESCRIPTION
## Summary
- Add African Puzzle logo to Sveltia CMS config
- Apply brand color (purple #8C30F5) and typography (Montserrat/Nunito fonts)
- Update favicons to use available PNG assets instead of missing SVG

🤖 Generated with [Claude Code](https://claude.com/claude-code)