### PR TITLE
Enable GitHub OAuth on Sveltia CMS

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,6 +2,7 @@ backend:
   name: github
   repo: african-puzzle/website-frontend
   branch: main
+  base_url: https://sveltia-cms-auth.proverb-drinker9c.workers.dev
 
 site_url: https://africanpuzzle.com
 display_url: https://africanpuzzle.com


### PR DESCRIPTION
## Summary
Configure GitHub OAuth login for the CMS admin panel by adding the sveltia-cms-auth Cloudflare Worker as the OAuth provider. The worker handles the server-side token exchange that static hosting on GitHub Pages cannot perform directly.

## Changes
- Updated `config.yml` to point the CMS backend to the OAuth worker at `https://sveltia-cms-auth.proverb-drinker9c.workers.dev`

## Testing
Visit https://admin.africanpuzzle.com to confirm the GitHub login button appears and the OAuth flow completes successfully.

🤖 Generated with Claude Code