### PR TITLE
Fix reserved 'body' field name in CMS file collections

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -120,7 +120,7 @@ collections:
         file: src/content/countries/countries.json
         fields:
           - label: Countries
-            name: body
+            name: countries
             widget: list
             fields:
               - { label: ID, name: id, widget: string }
@@ -136,34 +136,28 @@ collections:
         label: General Settings
         file: src/content/settings/site.json
         fields:
-          - label: Settings
-            name: body
-            widget: list
-            max: 1
-            fields:
-              - { label: ID, name: id, widget: hidden, default: 'site' }
-              - label: Play Store URL
-                name: playStoreUrl
-                widget: string
-                pattern: ['^https://play\.google\.com/store/apps/details\?id=.*$', 'Must be a valid Google Play Store URL']
-              - label: YouTube Video ID
-                name: youtubeVideoId
-                widget: string
-                hint: "The 11-character ID from the YouTube URL (e.g. dQw4w9WgXcQ)"
-              - label: Contact Email
-                name: contactEmail
-                widget: string
-                pattern: ['^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', 'Must be a valid email address']
-              - { label: Contact Phone, name: contactPhone, widget: string }
-              - { label: Instagram Handle, name: instagramHandle, widget: string }
-              - { label: Instagram URL, name: instagramUrl, widget: string }
+          - label: Play Store URL
+            name: playStoreUrl
+            widget: string
+            pattern: ['^https://play\.google\.com/store/apps/details\?id=.*$', 'Must be a valid Google Play Store URL']
+          - label: YouTube Video ID
+            name: youtubeVideoId
+            widget: string
+            hint: "The 11-character ID from the YouTube URL (e.g. dQw4w9WgXcQ)"
+          - label: Contact Email
+            name: contactEmail
+            widget: string
+            pattern: ['^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', 'Must be a valid email address']
+          - { label: Contact Phone, name: contactPhone, widget: string, required: false, default: '' }
+          - { label: Instagram Handle, name: instagramHandle, widget: string }
+          - { label: Instagram URL, name: instagramUrl, widget: string }
 
       - name: social-links
         label: Social Links
         file: src/content/settings/social-links.json
         fields:
           - label: Links
-            name: body
+            name: social_links
             widget: list
             fields:
               - { label: ID, name: id, widget: string }
@@ -182,7 +176,7 @@ collections:
         file: src/content/settings/instagram.json
         fields:
           - label: Posts
-            name: body
+            name: posts
             widget: list
             fields:
               - { label: ID, name: id, widget: string }


### PR DESCRIPTION
## Summary

- Rename `name: body` → `name: countries` in the Countries collection (matches existing Astro custom parser `JSON.parse(text).countries`)
- Rename `name: body` → `name: social_links` in the Social Links collection
- Rename `name: body` → `name: posts` in the Instagram Feed collection
- Flatten General Settings from a `list/body` wrapper to direct top-level fields, so `site.json` is written as a flat object

`body` is a reserved Sveltia CMS field name (main Markdown content after frontmatter) and must not be used in JSON file collections.

## Required follow-up in `african-puzzle/website-frontend`

- Add `parser: (text) => JSON.parse(text).social_links` to the `socialLinks` content collection
- Add `parser: (text) => JSON.parse(text).posts` to the `instagram` content collection
- Migrate `src/content/settings/social-links.json` from `[...]` → `{"social_links": [...]}`
- Migrate `src/content/settings/instagram.json` from `[...]` → `{"posts": [...]}`

## Test plan

- [ ] CMS admin loads without validation errors
- [ ] Countries collection shows existing entries
- [ ] Site Settings > General Settings shows flat form (no nested list)
- [ ] Site Settings > Social Links shows all 7 entries
- [ ] Site Settings > Instagram Feed shows all posts
- [ ] Saving any of the above writes correct JSON to `website-frontend`

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)