### PR TITLE
Fix duplicate about-page entry blocking CMS login

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -171,19 +171,6 @@ collections:
               - { label: Show in Contact Page, name: showInContact, widget: boolean, default: false }
               - { label: Display Order, name: order, widget: number, value_type: int }
 
-      - name: about-page
-        label: About Page
-        file: src/content/settings/about-page.json
-        fields:
-          - label: Hero Image
-            name: heroImage
-            widget: image
-            hint: "The large background image at the top of the About page"
-          - label: Phone Mockup Image
-            name: phoneMockupImage
-            widget: image
-            hint: "The phone screenshot image shown in the purple card"
-
       - name: instagram
         label: Instagram Feed
         file: src/content/settings/instagram.json


### PR DESCRIPTION
## Summary
- The `site-settings` collection in `config.yml` had two file entries both named `about-page`, which caused Sveltia CMS to show a config error and block admin login
- Removed the incomplete first entry (missing `cardHeading` and `cardBody` fields) and kept the complete second entry

## Test plan
- [ ] Visit https://admin.africanpuzzle.com/ and confirm the CMS loads without the "Collection file names must be unique" error
- [ ] Verify the About Page settings are editable with all four fields (heroImage, phoneMockupImage, cardHeading, cardBody)

🤖 Generated with [Claude Code](https://claude.com/claude-code)